### PR TITLE
Fixed link for SC Fan Content Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ $ npm test
 Made with :heart: by clash fans.
 
 ----------
-This content is not affiliated with, endorsed, sponsored, or specifically approved by Supercell and Supercell is not responsible for it. For more information see [Supercell’s Fan Content Policy](www.supercell.com/fan-content-policy).
+This content is not affiliated with, endorsed, sponsored, or specifically approved by Supercell and Supercell is not responsible for it. For more information see [Supercell’s Fan Content Policy](http://www.supercell.com/fan-content-policy).


### PR DESCRIPTION
old link was redirecting to (https://github.com/martincarrera/clash-royale-api/blob/master/www.supercell.com/fan-content-policy)